### PR TITLE
remove subtotal row if it exists

### DIFF
--- a/lunchable_primelunch/primelunch.py
+++ b/lunchable_primelunch/primelunch.py
@@ -145,7 +145,7 @@ class PrimeLunch(LunchableApp):
         amazon_df = amazon_df.astype(dtype=expected_columns, copy=True, errors="raise")
         logger.info("Amazon Data File loaded: %s", self.file_path)
         return amazon_df
-    
+
     @classmethod
     def filter_amazon_transactions(cls, df: pd.DataFrame) -> pd.DataFrame:
         """

--- a/lunchable_primelunch/primelunch.py
+++ b/lunchable_primelunch/primelunch.py
@@ -100,7 +100,7 @@ class PrimeLunch(LunchableApp):
         pd.DataFrame
             The potentially modified dataframe.
         """
-        if (amazon_df.iloc[-1].astype(str).str.contains("=SUBTOTAL").any()):
+        if amazon_df.iloc[-1].astype(str).str.contains("=SUBTOTAL").any():
             amazon_df = amazon_df[:-1]
         return amazon_df
 


### PR DESCRIPTION
When I use the Amazon Order History Reporter plugin it creates a final row in the output CSV that looks something like this:
```
"=SUBTOTAL(103, A2:A11) & "" items""",,,,,"=SUBTOTAL(109,F2:F11)","=SUBTOTAL(109,G2:G11)","=SUBTOTAL(109,H2:H11)","=SUBTOTAL(109,I2:I11)","=SUBTOTAL(109,J2:J11)","=SUBTOTAL(109,K2:K11)",,
```

I run this tool just infrequently enough that I always forget I need to remove this line.  

This change checks for its existence and removes it from the dataframe of amazon order information